### PR TITLE
Adjust to nim.storage() change

### DIFF
--- a/ocr/packages/ocr/credential/index.js
+++ b/ocr/packages/ocr/credential/index.js
@@ -1,6 +1,6 @@
-function getSignedUrl(filename) {
+async function getSignedUrl(filename) {
     const nimbella = require('nim')
-    const bucket   = nimbella.storage()
+    const bucket   = await nimbella.storage()
 
     const file = bucket.file(filename)
     const expiration = 15 * 60 * 1000 // 15 minutes

--- a/printer/packages/printer/create/src/create.js
+++ b/printer/packages/printer/create/src/create.js
@@ -3,7 +3,7 @@ const uuidv4 = require('uuid/v4'),
       redis = nimbella.redis()
 
 async function getSignedUrl(filename) {
-    const bucket = nimbella.storage()
+    const bucket = await nimbella.storage()
     const file = bucket.file(filename)
     const expiration = 60 * 60 * 1000 // 60 minutes
 

--- a/printer/packages/printer/get/src/get.js
+++ b/printer/packages/printer/get/src/get.js
@@ -4,7 +4,7 @@ const nimbella = require('nim'),
 const response = (body, statusCode) => ({ statusCode: statusCode || 200, body })
 
 async function getSignedUrl(filename) {
-    const bucket = nimbella.storage()
+    const bucket = await nimbella.storage()
     const file = bucket.file(filename)
     const expiration = 10 * 60 * 1000 // 10 minutes
 


### PR DESCRIPTION
Issue nimbella-corp/main#621

The `ocr` and `printer` demos use `nim.storage()` whose return type is changed from `Bucket` to `Promise<Bucket>` as a result of ongoing work on bucket naming.

This PR adjusts to that change.  The merge of this PR should be coordinated to avoid undue delay between the following steps.
1.  Merge this PR.
2.  Redeploy the JS and PHP runtimes on `nimgcp`
3.  Re-install demos.