### PR TITLE
build.sh uses bash features so /bin/bash not sh

### DIFF
--- a/qrcode/packages/default/qr-java/build.sh
+++ b/qrcode/packages/default/qr-java/build.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e 
 
-# set to 'mave' to use maven
+# set to 'maven' to use maven
 # set to 'gradle' to use gradle
 BUILD="maven"
 


### PR DESCRIPTION
I find that the build.sh qr-java works on my mac but not on linux container that has both bash and sh installed.  Changing the interpreter name at the top of the script from sh to bash fixes this.  I think the script is using bash features.  On a mac, sh really invokes bash (though supposedly in a compatibility mode ... that mode may be tolerant of bash features when they don't conflict). 