### PR TITLE
Fix qr-java gradle builds

### DIFF
--- a/qrcode/packages/default/qr-java/build.sh
+++ b/qrcode/packages/default/qr-java/build.sh
@@ -11,7 +11,7 @@ if [ $BUILD == "maven" ]; then
     echo target/qr-1.0.0-jar-with-dependencies.jar > .include
 else
     if [ $BUILD == "gradle" ]; then
-        gradlew jar
+        gradle jar
         echo build/libs/qr-java-1.0.jar > .include
     else
         echo unknown builder

--- a/qrcode/packages/default/qr-java/settings.gradle
+++ b/qrcode/packages/default/qr-java/settings.gradle
@@ -1,0 +1,1 @@
+// Deliberately empty


### PR DESCRIPTION
There is an option to build `qr-java` using `gradle`.   It invokes `gradlew` but no gradle wrapper is present in the project.   On the other hand, the basic configuration works fine with globally installed `gradle` so

- I changed `gradlew` to `gradle`
- I added an empty `settings.gradle`

The latter is to guard against the possibility that there is a `settings.gradle` in a parent directory, which can disrupt the build.

The resulting build works with a globally installed `gradle` 6.7.